### PR TITLE
provide a simple css selector to old message

### DIFF
--- a/week-1/6-css-properties/index.html
+++ b/week-1/6-css-properties/index.html
@@ -21,7 +21,7 @@
           <p class="message__content">
             Where should we meet tomorrrow?
           </p>
-          <time class="message__time message__time--old">Yesterday, 7:25pm</time>
+          <time class="message__time">Yesterday, 7:25pm</time>
         </div>
         <div class="message">
           <div class="message__author">Luke</div>

--- a/week-1/6-css-properties/index.html
+++ b/week-1/6-css-properties/index.html
@@ -16,7 +16,7 @@
         <div class="site-header__title">Messages</div>
       </div>
       <div class="messages">
-        <div class="message">
+        <div class="message message--old">
           <div class="message__author">Won</div>
           <p class="message__content">
             Where should we meet tomorrrow?


### PR DESCRIPTION
Currently on [Week-1 > Exercise-6 > Point 4](https://github.com/Migracode-Barcelona/html-css-git-exercises/blob/master/week-1/6-css-properties/readme.md#L8) we ask:
> Make yesterday's message partially transparent to show it is old.

This is particularly confusing when learning the first CSS selectors, thus adding a specific class to the entire element will help to solve this.

See: https://migracodebarcelona.slack.com/archives/CMDSP2CQ2/p1584005696039700