### PR TITLE
provide base code without margin or padding

### DIFF
--- a/week-1/7-css-box/index.html
+++ b/week-1/7-css-box/index.html
@@ -5,7 +5,6 @@
     <title>7. CSS Box Model - HTML, CSS and Git Exercises</title>
     <link rel="stylesheet" href="/css/normalize.css" />
     <link rel="stylesheet" href="/css/week1.css" />
-    <link rel="stylesheet" href="/css/week1-pagination.css" />
     <link rel="stylesheet" href="styles.css" />
   </head>
 
@@ -21,14 +20,6 @@
         <li class="country">Andorra</li>
         <li class="country">Angola</li>
       </ul>
-      <div class="pages">
-        <a href="#" class="pages__page">1</a>
-        <a href="#" class="pages__page">2</a>
-        <a href="#" class="pages__page">3</a>
-        <span class="pages__separator">...</span>
-        <a href="#" class="pages__page">38</a>
-        <span class="pages__showing">Showing 5 of 190</span>
-      </div>
     </div>
   </body>
 </html>

--- a/week-1/7-css-box/styles.css
+++ b/week-1/7-css-box/styles.css
@@ -1,6 +1,10 @@
 /* Try different box model properties below */
-.pages__page {
-  border: 1px solid #4491db;
-  border-radius: 4px;
+.countries {
+  list-style: none;
+  border-bottom: 1px solid #bbb;
+}
+
+.country {
   background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION

The code we provide already matches the final result. This happens because of the
CSS files are imported from another exercise. This commit removes the import and
adds only the base styles without any margin or padding.

The exercise asks the following:

> 2. Right now, the countries are too close to each other. Use the box model properties you have learned so that the name of the country has white space around it on all sides.

With the current changes this is what the students will see:
<img width="477" alt="Screen Shot 2020-03-24 at 11 26 22 PM" src="https://user-images.githubusercontent.com/33835/77482717-e51e4400-6e26-11ea-90a2-d6075ea018ea.png">

And this is the expected output:
![countries](https://user-images.githubusercontent.com/33835/77482539-6c1eec80-6e26-11ea-8916-d3839288435f.png)

Reference: https://migracodebarcelona.slack.com/archives/CU7AHBFR9/p1584199895029900?thread_ts=1584199298.023200
